### PR TITLE
improve window refocusing from system tray

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -68,7 +68,11 @@ async fn main() {
                 }
                 "open" => {
                     let window = app.get_window("main").unwrap();
-                    window.maximize().unwrap();
+                    // doesn't guarantee that window is brought to front
+                    // but should work for most desktops.
+                    window.show().unwrap();
+                    window.unminimize().unwrap(); 
+                    window.set_focus().unwrap();
                 }
                 _ => {
                     eprintln!("Unknown menu item: {}", id);


### PR DESCRIPTION
calling `Window#maximize()` may lead to a bugged window since it is not resizable.

Pulled from https://github.com/Levminer/authme/blob/7f3b9063bba2d2450e59ebcd20b52f144c273a59/core/src/main.rs#L41